### PR TITLE
Grammar for syntax highlighting in Atom

### DIFF
--- a/language-revbayes/grammars/revbayes.cson
+++ b/language-revbayes/grammars/revbayes.cson
@@ -1,0 +1,70 @@
+#
+#
+#       This is a simple(incomplete) grammar for working with RevBayes in the Atom text
+#       editor.It should work with any themes that respect the TextMate nomenclature,
+#       but I haven't tested it extensively in any sense of the word.
+#
+#       Maintainer: Tim Gervascio <tim.gervascio@gmail.com>
+#
+#
+scopeName: 'source.rb'
+name: 'RevBayes'
+fileTypes: [
+  'rb'
+  'rev'
+  'Rev'
+]
+
+patterns: [
+  {
+        #number
+        match: '(\\d+\\.?\\d+)|(\\d+)'
+        name: 'constant.numeric'
+  }
+  {
+        #comments with # delimiter
+        match: '#.*$'
+        name: 'comment'
+  }
+  {
+        #revbayes procedures
+        #as pointed out in M. Landis' Vim grammar this should be done procedurally, but this is just  first pass really.
+        match: '\\b(mcmc|model|readTrees|readDiscreteCharacterData|readContinuousCharacterData|readDataDelimitedFile|clade)'
+        name: 'entity.name.function'
+  }
+  {
+        #special statements
+        match: '\\b(NULL|true|false|NA|Inf|NaN)'
+        name: 'keyword.operator'
+  }
+  {
+        #functional statements
+        match: '\\b(break|next|return|if|else|for|in|repeat|while)'
+        name: 'keyword.control'
+  }
+  {
+        #revbayes functions/distributions etc.
+        match: '(dn\\w*)|(mv\\w*)|(mn\\w*)|(fn\\w*)'
+        name: 'storage.function'
+  }
+  {
+        #variables declared with <- operator
+        match: '(^\\S*)(| )(?=\\<-)'
+        name: 'variable.other'
+  }
+  {
+        #variables declared with ~ operator
+        match: '(^\\S*)(| )(?=\\~)'
+        name: 'variable.other'
+  }
+  {
+        #variables declared with = operator
+        match: '(^\\S*)(| )(?=\\:=)'
+        name: 'variable.other'
+  }
+  {
+        #constants declared with = operator
+        match: '(^\\S*)(| )(?=\\=)'
+        name: 'variable.other'
+  }
+]

--- a/language-revbayes/package.json
+++ b/language-revbayes/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "language-revbayes",
+  "version": "0.0.0",
+  "description": "A quick little cson grammar for syntax highlighting of RevBayes code in Atom",
+  "keywords": [
+    "language",
+    "grammar"
+  ],
+  "repository": "https://github.com/",
+  "license": "MIT",
+  "engines": {
+    "atom": ">=1.0.0 <2.0.0"
+  }
+}

--- a/language-revbayes/readme.md
+++ b/language-revbayes/readme.md
@@ -1,0 +1,17 @@
+This is a quick, simple, and incomplete RevBayes grammar for use in the Atom text editor. It uses TextMate naming conventions that should work with any proper Atom theme. It may even work in other editors if they support CoffeeScript grammars, but I haven't done any testing.
+
+It should automatically recognize Rev source files by the file extensions .rb or .Rev.
+
+#Easy Installation
+
+You should be able to get this working simply by searching for 'language-revbayes' under the packages heading in the Atom settings and installing from there.
+
+#Manual Installation
+
+Alternatively, you can install the package manually by placing the `language-revabyes/` directory into `~/.atom/packages/`.
+
+That would look something like this (double check the URL):
+```
+git clone https://github.com/revbayes/revbayes-editor/extra/atom
+mkdir -p ~/.atom/packages && cp -r ./language-revbayes ~/.atom/packages/
+```


### PR DESCRIPTION
A simple little grammar for syntax highlighting of Rev code in the Atom text editor.